### PR TITLE
Add SVN supported repo version message to install

### DIFF
--- a/NIPKG/pkg-ext/ext-src/control/control
+++ b/NIPKG/pkg-ext/ext-src/control/control
@@ -18,3 +18,6 @@ StoreProduct: Yes
 Suggests: 
 UserVisible: Yes
 Version: 3.0.0.5
+XB-MessageText-1: SVN Version Support
+  Note: This toolkit does not yet support repositories created using using SVN 1.10 or greater
+Version: 3.0.0.5


### PR DESCRIPTION
The message will look like this during install:
![svn version support](https://user-images.githubusercontent.com/6579561/58206116-b931af80-7ca5-11e9-9efd-853564422f14.PNG)
